### PR TITLE
Refactor the way program versions get created

### DIFF
--- a/Framework/Source/API/ComputeStateObject.h
+++ b/Framework/Source/API/ComputeStateObject.h
@@ -46,12 +46,12 @@ namespace Falcor
         {
         public:
             Desc& setRootSignature(RootSignature::SharedPtr pSignature) { mpRootSignature = pSignature; return *this; }
-            Desc& setProgramVersion(ProgramVersion::SharedConstPtr pProgram) { mpProgram = pProgram; return *this; }
-            ProgramVersion::SharedConstPtr getProgramVersion() const { return mpProgram; }
+            Desc& setProgramKernels(ProgramKernels::SharedConstPtr pProgram) { mpProgram = pProgram; return *this; }
+            ProgramKernels::SharedConstPtr getProgramKernels() const { return mpProgram; }
             bool operator==(const Desc& other) const;
         private:
             friend class ComputeStateObject;
-            ProgramVersion::SharedConstPtr mpProgram;
+            ProgramKernels::SharedConstPtr mpProgram;
             RootSignature::SharedPtr mpRootSignature;
         };
 

--- a/Framework/Source/API/D3D12/D3DProgramVersion.cpp
+++ b/Framework/Source/API/D3D12/D3DProgramVersion.cpp
@@ -33,12 +33,12 @@
 
 namespace Falcor
 {
-    void ProgramVersion::deleteApiHandle()
+    void ProgramKernels::deleteApiHandle()
     {
 
     }
 
-    bool ProgramVersion::init(std::string& log)
+    bool ProgramKernels::init(std::string& log)
     {
         return true;
     }

--- a/Framework/Source/API/GraphicsStateObject.h
+++ b/Framework/Source/API/GraphicsStateObject.h
@@ -68,7 +68,7 @@ namespace Falcor
             Desc& setRootSignature(RootSignature::SharedPtr pSignature) { mpRootSignature = pSignature; return *this; }
             Desc& setVertexLayout(VertexLayout::SharedConstPtr pLayout) { mpLayout = pLayout; return *this; }
             Desc& setFboFormats(const Fbo::Desc& fboFormats) { mFboDesc = fboFormats; return *this; }
-            Desc& setProgramVersion(ProgramVersion::SharedConstPtr pProgram) { mpProgram = pProgram; return *this; }
+            Desc& setProgramKernels(ProgramKernels::SharedConstPtr pProgram) { mpProgram = pProgram; return *this; }
             Desc& setBlendState(BlendState::SharedPtr pBlendState) { mpBlendState = pBlendState; return *this; }
             Desc& setRasterizerState(RasterizerState::SharedPtr pRasterizerState) { mpRasterizerState = pRasterizerState; return *this; }
             Desc& setDepthStencilState(DepthStencilState::SharedPtr pDepthStencilState) { mpDepthStencilState = pDepthStencilState; return *this; }
@@ -83,7 +83,7 @@ namespace Falcor
             GraphicsStateObject::PrimitiveType getPrimitiveType() const { return mPrimType; }
             VertexLayout::SharedConstPtr getVertexLayout() const { return mpLayout; }
             const Fbo::Desc& getFboDesc() const { return mFboDesc; }
-            ProgramVersion::SharedConstPtr getProgramVersion() const { return mpProgram; }
+            ProgramKernels::SharedConstPtr getProgramKernels() const { return mpProgram; }
 
             bool getSinglePassStereoEnabled() const { return mSinglePassStereoEnabled; }
 
@@ -93,7 +93,7 @@ namespace Falcor
             friend class GraphicsStateObject;
             VertexLayout::SharedConstPtr mpLayout;
             Fbo::Desc mFboDesc;
-            ProgramVersion::SharedConstPtr mpProgram;
+            ProgramKernels::SharedConstPtr mpProgram;
             RasterizerState::SharedPtr mpRasterizerState;
             DepthStencilState::SharedPtr mpDepthStencilState;
             BlendState::SharedPtr mpBlendState;

--- a/Framework/Source/API/Vulkan/VKProgramVersion.cpp
+++ b/Framework/Source/API/Vulkan/VKProgramVersion.cpp
@@ -30,12 +30,12 @@
 
 namespace Falcor
 {
-    void ProgramVersion::deleteApiHandle()
+    void ProgramKernels::deleteApiHandle()
     {
 
     }
 
-    bool ProgramVersion::init(std::string& log)
+    bool ProgramKernels::init(std::string& log)
     {
         return true;
     }

--- a/Framework/Source/Graphics/ComputeState.cpp
+++ b/Framework/Source/Graphics/ComputeState.cpp
@@ -40,12 +40,12 @@ namespace Falcor
 
     ComputeStateObject::SharedPtr ComputeState::getCSO(const ComputeVars* pVars)
     {
-        ProgramVersion::SharedConstPtr pProgVersion = mpProgram ? mpProgram->getActiveVersion() : nullptr;
-        bool newProgram = (pProgVersion.get() != mCachedData.pProgramVersion);
+        ProgramKernels::SharedConstPtr pProgramKernels = mpProgram ? mpProgram->getActiveVersion()->getKernels(pVars) : nullptr;
+        bool newProgram = (pProgramKernels.get() != mCachedData.pProgramKernels);
         if (newProgram)
         {
-            mCachedData.pProgramVersion = pProgVersion.get();
-            mpCsoGraph->walk((void*)mCachedData.pProgramVersion);
+            mCachedData.pProgramKernels = pProgramKernels.get();
+            mpCsoGraph->walk((void*)mCachedData.pProgramKernels);
         }
 
         RootSignature::SharedPtr pRoot = pVars ? pVars->getRootSignature() : RootSignature::getEmpty();
@@ -60,7 +60,7 @@ namespace Falcor
 
         if(pCso == nullptr)
         {
-            mDesc.setProgramVersion(pProgVersion);
+            mDesc.setProgramKernels(pProgramKernels);
             mDesc.setRootSignature(pRoot);
 
             StateGraph::CompareFunc cmpFunc = [&desc = mDesc](ComputeStateObject::SharedPtr pCso) -> bool

--- a/Framework/Source/Graphics/ComputeState.h
+++ b/Framework/Source/Graphics/ComputeState.h
@@ -73,7 +73,7 @@ namespace Falcor
 
         struct CachedData
         {
-            const ProgramVersion* pProgramVersion = nullptr;
+            const ProgramKernels* pProgramKernels = nullptr;
             const RootSignature* pRootSig = nullptr;
         };
         CachedData mCachedData;

--- a/Framework/Source/Graphics/GraphicsState.cpp
+++ b/Framework/Source/Graphics/GraphicsState.cpp
@@ -74,12 +74,12 @@ namespace Falcor
         {
             mpVao->getVertexLayout()->addVertexAttribDclToProg(mpProgram.get());
         }
-        const ProgramVersion::SharedConstPtr pProgVersion = mpProgram ? mpProgram->getActiveVersion() : nullptr;
-        bool newProgVersion = pProgVersion.get() != mCachedData.pProgramVersion;
+        const ProgramKernels::SharedConstPtr pProgramKernels = mpProgram ? mpProgram->getActiveVersion()->getKernels(pVars) : nullptr;
+        bool newProgVersion = pProgramKernels.get() != mCachedData.pProgramKernels;
         if (newProgVersion)
         {
-            mCachedData.pProgramVersion = pProgVersion.get();
-            mpGsoGraph->walk((void*)pProgVersion.get());
+            mCachedData.pProgramKernels = pProgramKernels.get();
+            mpGsoGraph->walk((void*)pProgramKernels.get());
         }
     
         RootSignature::SharedPtr pRoot = pVars ? pVars->getRootSignature() : RootSignature::getEmpty();
@@ -100,7 +100,7 @@ namespace Falcor
         GraphicsStateObject::SharedPtr pGso = mpGsoGraph->getCurrentNode();
         if(pGso == nullptr)
         {
-            mDesc.setProgramVersion(pProgVersion);
+            mDesc.setProgramKernels(pProgramKernels);
             mDesc.setFboFormats(mpFbo ? mpFbo->getDesc() : Fbo::Desc());
 #ifdef FALCOR_VK
             mDesc.setRenderPass(mpFbo ? (VkRenderPass)mpFbo->getApiHandle() : VK_NULL_HANDLE);

--- a/Framework/Source/Graphics/GraphicsState.h
+++ b/Framework/Source/Graphics/GraphicsState.h
@@ -253,7 +253,7 @@ namespace Falcor
 
         struct CachedData
         {
-            const ProgramVersion* pProgramVersion = nullptr;
+            const ProgramKernels* pProgramKernels = nullptr;
             const RootSignature* pRootSig = nullptr;
             const Fbo::Desc* pFboDesc = nullptr;
         };

--- a/Framework/Source/Graphics/Program/Program.h
+++ b/Framework/Source/Graphics/Program/Program.h
@@ -31,6 +31,8 @@
 #include <vector>
 #include "Graphics/Program//ProgramVersion.h"
 
+struct SlangCompileRequest;
+
 namespace Falcor
 {
     class Shader;
@@ -218,13 +220,23 @@ namespace Falcor
         void replaceAllDefines(const DefineList& dl) { mDefineList = dl; }
 
     protected:
+        friend class ProgramVersion;
+
         Program();
 
         void init(Desc const& desc, DefineList const& programDefines);
 
         bool link() const;
+
+        SlangCompileRequest* createSlangCompileRequest(DefineList const& defines) const;
+        int Program::doSlangCompilation(SlangCompileRequest* slangRequest, std::string& log) const;
+
         ProgramVersion::SharedPtr preprocessAndCreateProgramVersion(std::string& log) const;
-        virtual ProgramVersion::SharedPtr createProgramVersion(std::string& log, const Shader::Blob shaderBlob[kShaderCount]) const;
+        ProgramKernels::SharedPtr preprocessAndCreateProgramKernels(
+            ProgramVersion const* pVersion,
+            ProgramVars    const* pVars,
+            std::string         & log) const;
+        virtual ProgramKernels::SharedPtr createProgramKernels(std::string& log, const Shader::Blob shaderBlob[kShaderCount]) const;
 
         // The description used to create this program
         Desc mDesc;


### PR DESCRIPTION
Right now user code assumes that it can create a `Program`, (optionally) set some `#define`s, and then extract a `ProgramVersion` with `getActiveVersion` to get both:

- Reflection information, suitable to use with any similar/compatible versions
- Actual bind-able shader kernels, that can go into a PSO

The problem that arises here is that in some cases (e.g., when adding "shader components" support) we need to use information from the `ProgramVars` to inform the generation of bind-able shader kernels. For example, if we have a global-scope type parameter to stand in for a material type, then we can't generate final code until we plug in a concrete type for that parameter.

Trying to create a `ProgramVersion` without that additional info can currently lead to compilation failure ("you didn't tell me a concrete type here, so what code am I supposed to generate"). However, we currently can't create a `ProgamVars` (or the related reflection data) without creating a `ProgramVersion` first.

The root of the problem is that we don't want a single operation that both gets/creates reflection information *and* compiled kernel code, but rather we want thse to be two different steps.
This change tries to refactor the design along those lines, without changing the common case for user code (so that application code doesn't need to change).

Notes:

- Most of what `ProgramVersion` used to hold is now a new `ProgramKernels` type, that just holds the final `Shader` objects
  - Graphics and compute state objects now hold `ProgramKernels` instead of `ProgramVersion`s

- A new `ProgramVersion` type is created that is conceptually a "snapshot" of a `Program` given the `#define`s that were active when the snapshot was taken.

- `Program::getActiveVersion` applies the Slang compiler to the input code (given the active defines), but explicitly does *not* extract compiled kernel code. It passes on the resulting reflection data to create a `ProgramVersion`.
  - Note: the Slang API still receives exactly the same input right now, so the error cases are still errors with just this change.

- Currently there is a bottleneck (in `GraphicsState::getPSO` and `ComputeState::getGSO`) where the actual kernels are needed (because the state objects store the kernels), and it just so happens that we have a `ProgramVars` available in each of those cases (this is not coincidental). We can thus invoke a new operation at that point that takes into account the `ProgramVersion` (which remembers the `Program` and the `#define`s) *and* the `ProgramVars` and generates final kernel code.

- In order to minimize duplication, both of these compile steps share a lot of the Slang API calls via subroutines.

- There is currently no attempt made to actually use information from the `ProgramVars`, and the "caching" logic in `ProgramVersion` for re-using `ProgramKernels` is stubbed out (there is only one cached set of kernels).