### PR TITLE
Refactor material shader code to use interfaces

### DIFF
--- a/Framework/Source/API/ComputeContext.cpp
+++ b/Framework/Source/API/ComputeContext.cpp
@@ -89,13 +89,13 @@ namespace Falcor
         mpComputeStateStack.pop();
     }
 
-    void ComputeContext::applyComputeVars() 
+    void ComputeContext::applyComputeVars(RootSignature* rootSignature) 
     {
-        if (mpComputeVars->apply(const_cast<ComputeContext*>(this), mBindComputeRootSig) == false)
+        if (mpComputeVars->apply(const_cast<ComputeContext*>(this), mBindComputeRootSig, rootSignature) == false)
         {
             logWarning("ComputeContext::prepareForDispatch() - applying ComputeVars failed, most likely because we ran out of descriptors. Flushing the GPU and retrying");
             flush(true);
-            bool b = mpComputeVars->apply(const_cast<ComputeContext*>(this), mBindComputeRootSig);
+            bool b = mpComputeVars->apply(const_cast<ComputeContext*>(this), mBindComputeRootSig, rootSignature);
             assert(b);
         }
     }

--- a/Framework/Source/API/ComputeContext.h
+++ b/Framework/Source/API/ComputeContext.h
@@ -109,7 +109,7 @@ namespace Falcor
     protected:
         ComputeContext();
         void prepareForDispatch();
-        void applyComputeVars();
+        void applyComputeVars(RootSignature* rootSignature);
 
         std::stack<ComputeState::SharedPtr> mpComputeStateStack;
         std::stack<ComputeVars::SharedPtr> mpComputeVarsStack;

--- a/Framework/Source/API/D3D12/D3D12ComputeContext.cpp
+++ b/Framework/Source/API/D3D12/D3D12ComputeContext.cpp
@@ -37,17 +37,20 @@ namespace Falcor
     {
         assert(mpComputeState);
 
+        auto cso = mpComputeState->getCSO(mpComputeVars.get());
+        auto rootSignature = cso->getDesc().getProgramKernels()->getRootSignature();
+        if (mBindComputeRootSig)
+        {
+            mpLowLevelData->getCommandList()->SetComputeRootSignature(rootSignature->getApiHandle());
+            mBindComputeRootSig = false;
+        }
+
         // Apply the vars. Must be first because applyComputeVars() might cause a flush        
         if (mpComputeVars)
         {
-            applyComputeVars();
+            applyComputeVars(rootSignature.get());
         }
-        else
-        {
-            mpLowLevelData->getCommandList()->SetComputeRootSignature(RootSignature::getEmpty()->getApiHandle());
-        }
-        mBindComputeRootSig = false;
-        mpLowLevelData->getCommandList()->SetPipelineState(mpComputeState->getCSO(mpComputeVars.get())->getApiHandle());
+        mpLowLevelData->getCommandList()->SetPipelineState(cso->getApiHandle());
         mCommandsPending = true;
     }
 

--- a/Framework/Source/API/RenderContext.cpp
+++ b/Framework/Source/API/RenderContext.cpp
@@ -108,13 +108,13 @@ namespace Falcor
         }
     }
 
-    void RenderContext::applyGraphicsVars()
+    void RenderContext::applyGraphicsVars(RootSignature* rootSignature)
     {
-        if (mpGraphicsVars->apply(const_cast<RenderContext*>(this), mBindGraphicsRootSig) == false)
+        if (mpGraphicsVars->apply(const_cast<RenderContext*>(this), mBindGraphicsRootSig, rootSignature) == false)
         {
             logWarning("RenderContext::prepareForDraw() - applying GraphicsVars failed, most likely because we ran out of descriptors. Flushing the GPU and retrying");
             flush(true);
-            bool b = mpGraphicsVars->apply(const_cast<RenderContext*>(this), mBindGraphicsRootSig);
+            bool b = mpGraphicsVars->apply(const_cast<RenderContext*>(this), mBindGraphicsRootSig, rootSignature);
             assert(b);
         }
     }

--- a/Framework/Source/API/RenderContext.h
+++ b/Framework/Source/API/RenderContext.h
@@ -187,7 +187,7 @@ namespace Falcor
         compute context's initDispatchCommandSignature() to create command signature for dispatchIndirect
         */
         static void initDrawCommandSignatures();
-        void applyGraphicsVars();
+        void applyGraphicsVars(RootSignature* rootSignature);
 
         // Internal functions used by the API layers
         void prepareForDraw();

--- a/Framework/Source/Data/Framework/Shaders/MaterialBlock.slang
+++ b/Framework/Source/Data/Framework/Shaders/MaterialBlock.slang
@@ -25,6 +25,7 @@
 # (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***************************************************************************/
+#include "HostDeviceData.h"
 __import ShaderCommon;
 ParameterBlock<MaterialData> materialBlock;
 

--- a/Framework/Source/Data/ShaderCommon.slang
+++ b/Framework/Source/Data/ShaderCommon.slang
@@ -29,11 +29,11 @@
 /*******************************************************************
                     Common OGL bindings
 *******************************************************************/
+#include "HostDeviceSharedMacros.h"
 
 #ifndef _FALCOR_SHADER_COMMON_H_
 #define _FALCOR_SHADER_COMMON_H_
-
-#include "HostDeviceData.h"
+__import Shading;
 
 cbuffer InternalPerFrameCB : register(b10)
 {
@@ -80,7 +80,10 @@ float3x3 getBlendedInvTransposeBoneMat(float4 weights, uint4 ids)
 }
 #endif
 
-ParameterBlock<MaterialData> gMaterial;
+__generic_param TMaterial : IMaterial;
+
+ParameterBlock<TMaterial> gMaterial;
+
 cbuffer InternalPerMaterialCB
 {
     MaterialData gTemporalMaterial;

--- a/Framework/Source/Graphics/ComputeState.cpp
+++ b/Framework/Source/Graphics/ComputeState.cpp
@@ -48,7 +48,7 @@ namespace Falcor
             mpCsoGraph->walk((void*)mCachedData.pProgramKernels);
         }
 
-        RootSignature::SharedPtr pRoot = pVars ? pVars->getRootSignature() : RootSignature::getEmpty();
+        RootSignature::SharedPtr pRoot = pProgramKernels ? pProgramKernels->getRootSignature() : RootSignature::getEmpty();
 
         if (mCachedData.pRootSig != pRoot.get())
         {

--- a/Framework/Source/Graphics/GraphicsState.cpp
+++ b/Framework/Source/Graphics/GraphicsState.cpp
@@ -82,7 +82,7 @@ namespace Falcor
             mpGsoGraph->walk((void*)pProgramKernels.get());
         }
     
-        RootSignature::SharedPtr pRoot = pVars ? pVars->getRootSignature() : RootSignature::getEmpty();
+        RootSignature::SharedPtr pRoot = pProgramKernels ? pProgramKernels->getRootSignature() : RootSignature::getEmpty();
 
         if (mCachedData.pRootSig != pRoot.get())
         {

--- a/Framework/Source/Graphics/Program/Program.cpp
+++ b/Framework/Source/Graphics/Program/Program.cpp
@@ -342,7 +342,7 @@ namespace Falcor
         SlangCompileFlags slangFlags = 0;
 
         // Don't actually perform semantic checking: just pass through functions bodies to downstream compiler
-        slangFlags |= SLANG_COMPILE_FLAG_NO_CHECKING | SLANG_COMPILE_FLAG_SPLIT_MIXED_TYPES;
+        slangFlags |= /*SLANG_COMPILE_FLAG_NO_CHECKING |*/ SLANG_COMPILE_FLAG_SPLIT_MIXED_TYPES;
 
         slangFlags |= SLANG_COMPILE_FLAG_USE_IR;
 
@@ -518,11 +518,13 @@ namespace Falcor
             }           
         }
 
+        auto rootSignature = RootSignature::create(mPreprocessedReflector.get());
+
         if (shaders[(uint32_t)ShaderType::Compute])
         {
             return ProgramKernels::create(
                 mPreprocessedReflector,
-                shaders[(uint32_t)ShaderType::Compute], log, getProgramDescString());
+                shaders[(uint32_t)ShaderType::Compute], rootSignature, log, getProgramDescString());
         }
         else
         {
@@ -533,6 +535,7 @@ namespace Falcor
                 shaders[(uint32_t)ShaderType::Geometry],
                 shaders[(uint32_t)ShaderType::Hull],
                 shaders[(uint32_t)ShaderType::Domain],
+                rootSignature,
                 log,
                 getProgramDescString());
         }

--- a/Framework/Source/Graphics/Program/ProgramReflection.cpp
+++ b/Framework/Source/Graphics/Program/ProgramReflection.cpp
@@ -453,6 +453,12 @@ namespace Falcor
         return pArrayType;
     }
 
+    ReflectionType::SharedPtr reflectGenericTypeParameterType(TypeLayoutReflection* pSlangType, const ReflectionPath* pPath)
+    {
+        ReflectionGenericType::SharedPtr result = ReflectionGenericType::create(pSlangType->getName());
+        return result;
+    }
+
     ReflectionType::SharedPtr reflectBasicType(TypeLayoutReflection* pSlangType, const ReflectionPath* pPath)
     {
         ReflectionBasicType::Type type = getVariableType(pSlangType->getScalarType(), pSlangType->getRowCount(), pSlangType->getColumnCount());
@@ -476,6 +482,8 @@ namespace Falcor
             return reflectStructType(pSlangType, pPath);
         case TypeReflection::Kind::Array:
             return reflectArrayType(pSlangType, pPath);
+        case TypeReflection::Kind::GenericTypeParameter:
+            return reflectGenericTypeParameterType(pSlangType, pPath);
         default:
             return reflectBasicType(pSlangType, pPath);
         }
@@ -1137,6 +1145,11 @@ namespace Falcor
         return dynamic_cast<const ReflectionArrayType*>(this);
     }
 
+    const ReflectionGenericType * ReflectionType::asGenericType() const
+    {
+        return dynamic_cast<const ReflectionGenericType*>(this);
+    }
+
     const ReflectionType* ReflectionType::unwrapArray() const
     {
         const ReflectionType* pType = this;
@@ -1184,6 +1197,12 @@ namespace Falcor
                 extractOffsets(pType, offset + i * pArrayType->getArrayStride(), count, offsetMap);
                 --count;
             }
+            return;
+        }
+
+        const ReflectionGenericType* pGenericType = pType->asGenericType();
+        if (pGenericType)
+        {
             return;
         }
 
@@ -1251,6 +1270,18 @@ namespace Falcor
         const ReflectionArrayType* pOther = other.asArrayType();
         if (!pOther) return false;
         return (*this == *pOther);
+    }
+    
+    ReflectionGenericType::SharedPtr ReflectionGenericType::create(std::string inName)
+    {
+        return SharedPtr(new ReflectionGenericType(inName));
+    }
+
+    bool ReflectionGenericType::operator==(const ReflectionType& other) const
+    {
+        const ReflectionGenericType* pOther = other.asGenericType();
+        if (!pOther) return false;
+        return (name == pOther->name);
     }
 
     bool ReflectionResourceType::operator==(const ReflectionType& other) const

--- a/Framework/Source/Graphics/Program/ProgramReflection.h
+++ b/Framework/Source/Graphics/Program/ProgramReflection.h
@@ -39,6 +39,7 @@ namespace Falcor
     class ReflectionBasicType;
     class ReflectionStructType;
     class ReflectionArrayType;
+    class ReflectionGenericType;
 
     /** Base class for reflection types
     */
@@ -69,6 +70,11 @@ namespace Falcor
         /** Dynamic-cast the current object to ReflectionArrayType
         */
         const ReflectionArrayType* asArrayType() const;
+
+        /** Dynamic-cast the current object to ReflectionGenericType
+        */
+        const ReflectionGenericType* asGenericType() const;
+
 
         /** For ReflectionArrayType, recursively look for an underlying type which is not an array
         */
@@ -270,6 +276,30 @@ namespace Falcor
         size_t mSize;
         bool mIsRowMajor;
         virtual std::shared_ptr<const ReflectionVar> findMemberInternal(const std::string& name, size_t strPos, size_t offset, uint32_t regIndex, uint32_t regSpace, uint32_t descOffset) const override;
+    };
+
+    class ReflectionGenericType : public ReflectionType, public inherit_shared_from_this<ReflectionType, ReflectionGenericType>
+    {
+    public:
+        using SharedPtr = std::shared_ptr<ReflectionGenericType>;
+        using SharedConstPtr = std::shared_ptr<const ReflectionGenericType>;
+        std::string name;
+        static SharedPtr create(std::string inName);
+        virtual bool operator==(const ReflectionType& other) const override;
+        virtual size_t getSize() const override
+        {
+            return 0;
+        }
+        ReflectionGenericType(std::string inName)
+            : ReflectionType(0), name(inName)
+        {}
+    private:
+        
+        virtual std::shared_ptr<const ReflectionVar> findMemberInternal(const std::string& name, size_t strPos, size_t offset, uint32_t regIndex, uint32_t regSpace, uint32_t descOffset) const override
+        {
+            return nullptr;
+        }
+
     };
 
     /** Reflection object for resources

--- a/Framework/Source/Graphics/Program/ProgramVars.cpp
+++ b/Framework/Source/Graphics/Program/ProgramVars.cpp
@@ -77,19 +77,18 @@ namespace Falcor
         BlockData data;
         data.pBlock = ParameterBlock::create(pBlockReflection, createBuffers);
         // For each set, find the matching root-index. 
-        const auto& sets = pBlockReflection->getDescriptorSetLayouts();
+        /*const auto& sets = pBlockReflection->getDescriptorSetLayouts();
         data.rootIndex.resize(sets.size());
         for (size_t i = 0; i < sets.size(); i++)
         {
             data.rootIndex[i] = findRootIndex(sets[i], mpRootSignature);
-        }
+        }*/
 
         return data;
     }
 
-    ProgramVars::ProgramVars(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers, const RootSignature::SharedPtr& pRootSig) : mpReflector(pReflector)
+    ProgramVars::ProgramVars(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers) : mpReflector(pReflector)
     {
-        mpRootSignature = pRootSig ? pRootSig : RootSignature::create(pReflector.get());
         ParameterBlockReflection::SharedConstPtr pDefaultBlock = pReflector->getDefaultParameterBlock();
         // Initialize the global-block first so that it's the first entry in the vector
         for (uint32_t i = 0; i < pReflector->getParameterBlockCount(); i++)
@@ -140,14 +139,14 @@ namespace Falcor
         mParameterBlocks[blockIndex].pBlock = pBlock ? std::const_pointer_cast<ParameterBlock>(pBlock) : ParameterBlock::create(mpReflector->getParameterBlock(blockIndex), true);   // #PARAMBLOCK
     }
 
-    GraphicsVars::SharedPtr GraphicsVars::create(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers, const RootSignature::SharedPtr& pRootSig)
+    GraphicsVars::SharedPtr GraphicsVars::create(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers)
     {
-        return SharedPtr(new GraphicsVars(pReflector, createBuffers, pRootSig));
+        return SharedPtr(new GraphicsVars(pReflector, createBuffers));
     }
 
-    ComputeVars::SharedPtr ComputeVars::create(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers, const RootSignature::SharedPtr& pRootSig)
+    ComputeVars::SharedPtr ComputeVars::create(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers)
     {
-        return SharedPtr(new ComputeVars(pReflector, createBuffers, pRootSig));
+        return SharedPtr(new ComputeVars(pReflector, createBuffers));
     }
 
     ConstantBuffer::SharedPtr ProgramVars::getConstantBuffer(const std::string& name) const
@@ -259,44 +258,36 @@ namespace Falcor
     }
 
     template<bool forGraphics>
-    bool ProgramVars::applyProgramVarsCommon(CopyContext* pContext, bool bindRootSig)
+    bool ProgramVars::applyProgramVarsCommon(CopyContext* pContext, bool rootSigChanged, RootSignature* pRootSig)
     {
-        if (bindRootSig)
-        {
-            if (forGraphics)
-            {
-                mpRootSignature->bindForGraphics(pContext);
-            }
-            else
-            {
-                mpRootSignature->bindForCompute(pContext);
-            }
-        }
-
         // Bind the sets
         for(uint32_t b = 0 ; b < getParameterBlockCount() ; b++)
         {
             ParameterBlock* pBlock = mParameterBlocks[b].pBlock.get(); // #PARAMBLOCK getParameterBlock() because we don't want the user to change blocks directly, but we need it non-const here
             if (pBlock->prepareForDraw(pContext) == false) return false; // #PARAMBLOCK Get rid of it. getRootSets() should have a dirty flag
 
-            const auto& rootIndices = mParameterBlocks[b].rootIndex;
+            // SLANG-INTEGRATION
+            uint32_t rootCounter = 0;
+
             auto& rootSets = pBlock->getRootSets();
-            bool forceBind = bindRootSig || mParameterBlocks[b].bind;
+            bool forceBind = rootSigChanged || mParameterBlocks[b].bind;
             mParameterBlocks[b].bind = false;
 
             for (uint32_t s = 0; s < rootSets.size(); s++)
             {
+                uint32_t rootIndex = rootCounter;
+                rootCounter++;
+
                 if (rootSets[s].dirty || forceBind)
                 {
                     rootSets[s].dirty = false;
-                    uint32_t rootIndex = rootIndices[s];
                     if (forGraphics)
                     {
-                        rootSets[s].pSet->bindForGraphics(pContext, mpRootSignature.get(), rootIndex);
+                        rootSets[s].pSet->bindForGraphics(pContext, pRootSig, rootIndex);
                     }
                     else
                     {
-                        rootSets[s].pSet->bindForCompute(pContext, mpRootSignature.get(), rootIndex);
+                        rootSets[s].pSet->bindForCompute(pContext, pRootSig, rootIndex);
                     }
                 }
             }
@@ -304,13 +295,13 @@ namespace Falcor
         return true;
     }
 
-    bool ComputeVars::apply(ComputeContext* pContext, bool bindRootSig)
+    bool ComputeVars::apply(ComputeContext* pContext, bool rootSignatureChanged, RootSignature* pRootSig)
     {
-        return applyProgramVarsCommon<false>(pContext, bindRootSig);
+        return applyProgramVarsCommon<false>(pContext, rootSignatureChanged, pRootSig);
     }
 
-    bool GraphicsVars::apply(RenderContext* pContext, bool bindRootSig)
+    bool GraphicsVars::apply(RenderContext* pContext, bool rootSignatureChanged, RootSignature* pRootSig)
     {
-        return applyProgramVarsCommon<true>(pContext, bindRootSig);
+        return applyProgramVarsCommon<true>(pContext, rootSignatureChanged, pRootSig);
     }
 }

--- a/Framework/Source/Graphics/Program/ProgramVars.h
+++ b/Framework/Source/Graphics/Program/ProgramVars.h
@@ -222,7 +222,8 @@ namespace Falcor
 
         /** Get the root signature object
         */
-        RootSignature::SharedPtr getRootSignature() const { return mpRootSignature; }
+        // SLANG-INTEGRATION
+        //RootSignature::SharedPtr getRootSignature() const { return mpRootSignature; }
 
         /** Get the number of parameter-blocks
         */
@@ -230,7 +231,8 @@ namespace Falcor
         
         /** Get a list of indices translating a parameter-block's set index to the root-signature entry index
         */
-        const std::vector<uint32_t>& getParameterBlockRootIndices(uint32_t blockIndex) const { return mParameterBlocks[blockIndex].rootIndex; }
+        // SLANG-INTEGRATION: no longer needed
+        //const std::vector<uint32_t>& getParameterBlockRootIndices(uint32_t blockIndex) const { return mParameterBlocks[blockIndex].rootIndex; }
 
         /** Get parameter-block by index. You can translate a name to an index using the ProgramReflection object
         */
@@ -259,18 +261,21 @@ namespace Falcor
         ConstantBuffer::SharedPtr getConstantBuffer(uint32_t) const = delete;
 
         template<bool forGraphics>
-        bool applyProgramVarsCommon(CopyContext* pContext, bool bindRootSig);
+        bool applyProgramVarsCommon(CopyContext* pContext, bool rootSigChanged, RootSignature* rootSignature);
 
     protected:
-        ProgramVars(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers, const RootSignature::SharedPtr& pRootSig);
+        ProgramVars(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers);
         
-        RootSignature::SharedPtr mpRootSignature;
+        // SLANG-INTEGRATION
+        //RootSignature::SharedPtr mpRootSignature;
+
         ProgramReflection::SharedConstPtr mpReflector;
 
         struct BlockData
         {
             ParameterBlock::SharedPtr pBlock;
-            std::vector<uint32_t> rootIndex;        // Maps the block's set-index to the root-signature entry
+            // SLANG-INTEGRATION - should not need this
+            //std::vector<uint32_t> rootIndex;        // Maps the block's set-index to the root-signature entry
             bool bind = true;
         };
         BlockData mDefaultBlock;
@@ -289,11 +294,11 @@ namespace Falcor
             \param[in] createBuffers If true, will create the ConstantBuffer objects. Otherwise, the user will have to bind the CBs himself
             \param[in] pRootSignature A root-signature describing how to bind resources into the shader. If this parameter is nullptr, a root-signature object will be created from the program reflection object
         */
-        static SharedPtr create(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers = true, const RootSignature::SharedPtr& pRootSig = nullptr);
-        bool apply(RenderContext* pContext, bool bindRootSig);
+        static SharedPtr create(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers = true);
+        bool apply(RenderContext* pContext, bool rootSignatureChanged, RootSignature* rootSignature);
     private:
-        GraphicsVars(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers, const RootSignature::SharedPtr& pRootSig) :
-            ProgramVars(pReflector, createBuffers, pRootSig) {}
+        GraphicsVars(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers) :
+            ProgramVars(pReflector, createBuffers) {}
     };
 
     class ComputeVars : public ProgramVars, public std::enable_shared_from_this<ProgramVars>
@@ -307,10 +312,10 @@ namespace Falcor
             \param[in] createBuffers If true, will create the ConstantBuffer objects. Otherwise, the user will have to bind the CBs himself
             \param[in] pRootSignature A root-signature describing how to bind resources into the shader. If this parameter is nullptr, a root-signature object will be created from the program reflection object
         */
-        static SharedPtr create(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers = true, const RootSignature::SharedPtr& pRootSig = nullptr);
-        bool apply(ComputeContext* pContext, bool bindRootSig);
+        static SharedPtr create(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers = true);
+        bool apply(ComputeContext* pContext, bool rootSignatureChanged, RootSignature* rootSignature);
     private:
-        ComputeVars(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers, const RootSignature::SharedPtr& pRootSig) :
-            ProgramVars(pReflector, createBuffers, pRootSig) {}
+        ComputeVars(const ProgramReflection::SharedConstPtr& pReflector, bool createBuffers) :
+            ProgramVars(pReflector, createBuffers) {}
     };
 }

--- a/Framework/Source/Graphics/Program/ProgramVersion.cpp
+++ b/Framework/Source/Graphics/Program/ProgramVersion.cpp
@@ -32,7 +32,7 @@
 
 namespace Falcor
 {
-    ProgramKernels::ProgramKernels(const Shader::SharedPtr& pVS, const Shader::SharedPtr& pPS, const Shader::SharedPtr& pGS, const Shader::SharedPtr& pHS, const Shader::SharedPtr& pDS, const Shader::SharedPtr& pCS, const std::string& name) : mName(name)
+    ProgramKernels::ProgramKernels(const Shader::SharedPtr& pVS, const Shader::SharedPtr& pPS, const Shader::SharedPtr& pGS, const Shader::SharedPtr& pHS, const Shader::SharedPtr& pDS, const Shader::SharedPtr& pCS, const RootSignature::SharedPtr& pRootSignature, const std::string& name) : mName(name)
     {
         mpShaders[(uint32_t)ShaderType::Vertex] = pVS;
         mpShaders[(uint32_t)ShaderType::Pixel] = pPS;
@@ -40,6 +40,7 @@ namespace Falcor
         mpShaders[(uint32_t)ShaderType::Domain] = pDS;
         mpShaders[(uint32_t)ShaderType::Hull] = pHS;
         mpShaders[(uint32_t)ShaderType::Compute] = pCS;
+        mpRootSignature = pRootSignature;
     }
 
     ProgramKernels::SharedPtr ProgramKernels::create(
@@ -49,6 +50,7 @@ namespace Falcor
         const Shader::SharedPtr& pGS,
         const Shader::SharedPtr& pHS,
         const Shader::SharedPtr& pDS,
+        const RootSignature::SharedPtr& pRootSignature,
         std::string& log,
         const std::string& name)
     {
@@ -58,7 +60,7 @@ namespace Falcor
             log = "Program " + name + " doesn't contain a vertex-shader. This is illegal.";
             return nullptr;
         }
-        SharedPtr pProgram = SharedPtr(new ProgramKernels(pVS, pPS, pGS, pHS, pDS, nullptr, name));
+        SharedPtr pProgram = SharedPtr(new ProgramKernels(pVS, pPS, pGS, pHS, pDS, nullptr, pRootSignature, name));
 
         if(pProgram->init(log) == false)
         {
@@ -76,6 +78,7 @@ namespace Falcor
     ProgramKernels::SharedPtr ProgramKernels::create(
         ProgramReflection::SharedPtr const& pReflector,
         const Shader::SharedPtr& pCS,
+        const RootSignature::SharedPtr& pRootSignature,
         std::string& log,
         const std::string& name)
     {
@@ -85,7 +88,7 @@ namespace Falcor
             log = "Program " + name + " doesn't contain a compute-shader. This is illegal.";
             return nullptr;
         }
-        SharedPtr pProgram = SharedPtr(new ProgramKernels(nullptr, nullptr, nullptr, nullptr, nullptr, pCS, name));
+        SharedPtr pProgram = SharedPtr(new ProgramKernels(nullptr, nullptr, nullptr, nullptr, nullptr, pCS, pRootSignature, name));
 
         if (pProgram->init(log) == false)
         {

--- a/Framework/Source/Graphics/Program/ProgramVersion.h
+++ b/Framework/Source/Graphics/Program/ProgramVersion.h
@@ -32,6 +32,7 @@
 #include <vector>
 #include "API/Shader.h"
 #include "Graphics/Program//ProgramReflection.h"
+#include "API/LowLevel/RootSignature.h"
 
 namespace Falcor
 {
@@ -65,6 +66,7 @@ namespace Falcor
             const Shader::SharedPtr& pGS,
             const Shader::SharedPtr& pHS,
             const Shader::SharedPtr& pDS,
+            const RootSignature::SharedPtr& pRootSignature,
             std::string& log, 
             const std::string& name = "");
 
@@ -77,6 +79,7 @@ namespace Falcor
         static SharedPtr create(
             ProgramReflection::SharedPtr const& pReflector,
             const Shader::SharedPtr& pCS,
+            const RootSignature::SharedPtr& pRootSignature,
             std::string& log,
             const std::string& name = "");
 
@@ -92,7 +95,17 @@ namespace Falcor
 
         /** Get the reflection object
         */
+
         ProgramReflection::SharedConstPtr getReflector() const { return mpReflector; }
+        
+        // SLANG-INTEGRATION
+        // move root signature to be a member of ProgramKernels
+        RootSignature::SharedPtr mpRootSignature;
+        RootSignature::SharedPtr getRootSignature() const
+        {
+            return mpRootSignature;
+        }
+
     protected:
         ProgramKernels(const Shader::SharedPtr& pVS,
             const Shader::SharedPtr& pPS,
@@ -100,6 +113,7 @@ namespace Falcor
             const Shader::SharedPtr& pHS,
             const Shader::SharedPtr& pDS,
             const Shader::SharedPtr& pCS,
+            const RootSignature::SharedPtr& pRootSignature,
             const std::string& name = "");
 
         virtual bool init(std::string& log);
@@ -109,7 +123,6 @@ namespace Falcor
 
         static const uint32_t kShaderCount = (uint32_t)ShaderType::Count;
         Shader::SharedConstPtr mpShaders[kShaderCount];
-
         ProgramReflection::SharedPtr mpReflector;
         void* mpPrivateData;
     };

--- a/Framework/Source/ShadingUtils/Shading.slang
+++ b/Framework/Source/ShadingUtils/Shading.slang
@@ -35,6 +35,11 @@
 
 __import Helpers;
 
+interface IMaterial
+{
+    void prepare(inout ShadingAttribs shAttrib);
+}
+
 /*******************************************************************
 Documentation
 *******************************************************************/
@@ -98,13 +103,52 @@ __import BSDFs;
 Material shading building blocks
 *******************************************************************/
 
+struct Material : IMaterial
+{
+    MaterialData material;
+
+    void prepare(inout ShadingAttribs shAttr)
+    {
+        /* Copy the input material parameters */
+#ifdef _MS_STATIC_MATERIAL_DESC
+        MaterialDesc desc = _MS_STATIC_MATERIAL_DESC;
+#else
+        MaterialDesc desc = material.desc;
+#endif
+
+        shAttr.preparedMat.values = material.values;
+        shAttr.preparedMat.desc = desc;
+
+        /* Evaluate alpha test material modifier */
+        applyAlphaTest(material, shAttr, shAttr.P);
+        shAttr.aoFactor = 1;
+
+        bool done = false;
+        $for(iLayer in Range(0, MatMaxLayers))
+        {
+            if (shAttr.preparedMat.desc.layers[iLayer].type == MatNone)
+                done = true;
+
+            if (!done)
+            {
+                shAttr.preparedMat.values.layers[iLayer].albedo =
+                    evalWithColor(desc.layers[iLayer].hasTexture, material.textures.layers[iLayer], material.samplerState, material.values.layers[iLayer].albedo, shAttr);
+            }
+        }
+
+        /* Perturb shading normal is needed */
+        perturbNormal(material, shAttr);
+    }
+};
+
 /**
 Prepares all light-independent attributes needed to perform shading at a hit point.
 This includes fetching all textures and computing final shading attributes, like albedo and roughness.
 After this step, one can save these shading attributes, e.g., in a G-Buffer to perform lighting afterwards.
 This routine also applies all material modifiers, like performs alpha test and applies a normal map.
 */
-void _fn prepareShadingAttribs(MaterialData material, in float3 P, in float3 camPos,
+
+void prepareShadingAttribs<TMaterial:IMaterial>(TMaterial material, in float3 P, in float3 camPos,
     in float3 normal, in float3 bitangent, in float2 uv,
 #ifdef _MS_USER_DERIVATIVES
     float2 dPdx, float2 dPdy,
@@ -127,57 +171,14 @@ void _fn prepareShadingAttribs(MaterialData material, in float3 P, in float3 cam
     shAttr.lodBias = lodBias;
 #endif
 
-
-    /* Copy the input material parameters */
-#ifdef _MS_STATIC_MATERIAL_DESC
-    MaterialDesc desc = _MS_STATIC_MATERIAL_DESC;
-#else
-    MaterialDesc desc = material.desc;
-#endif
-
-    shAttr.preparedMat.values = material.values;
-    shAttr.preparedMat.desc = desc;
-
-    /* Evaluate alpha test material modifier */
-    applyAlphaTest(material, shAttr, P);
-    shAttr.aoFactor = 1;
-
-    /* Prefetch textures */
-#if 0
-    loop_unroll
-    for(uint iLayer = 0 ; iLayer < MatMaxLayers ; iLayer++)
-    {
-        if(shAttr.preparedMat.desc.layers[iLayer].type == MatNone) break;
-
-        shAttr.preparedMat.values.layers[iLayer].albedo = 
-            evalWithColor(desc.layers[iLayer].hasTexture, material.textures.layers[iLayer], material.samplerState, material.values.layers[iLayer].albedo, shAttr);
-    }
-#else
-    // SLANG: need to explicitly unroll to make IR emit
-    // code that keeps fxc happy
-    bool done = false;
-    $for(iLayer in Range(0, MatMaxLayers))
-    {
-        if(shAttr.preparedMat.desc.layers[iLayer].type == MatNone)
-            done = true;
-
-        if( !done )
-        {
-            shAttr.preparedMat.values.layers[iLayer].albedo = 
-                evalWithColor(desc.layers[iLayer].hasTexture, material.textures.layers[iLayer], material.samplerState, material.values.layers[iLayer].albedo, shAttr);
-        }
-    }
-#endif
-
-    /* Perturb shading normal is needed */
-    perturbNormal(material, shAttr);
+    material.prepare(shAttr);
 }
 
 /**
 Another overload of PrepareShadingAttribs(), which does not require tangents.
 Instead it constructs a world-space axis-aligned tangent frame on the fly.
 */
-void _fn prepareShadingAttribs(MaterialData material, in float3 P, in float3 camPos,
+void _fn prepareShadingAttribs<TMaterial:IMaterial>(TMaterial material, in float3 P, in float3 camPos,
     in float3 normal, in float2 uv,
 #ifdef _MS_USER_DERIVATIVES
     float2 dPdx, float2 dPdy,
@@ -201,12 +202,12 @@ void _fn prepareShadingAttribs(MaterialData material, in float3 P, in float3 cam
 
 #ifndef _MS_USER_DERIVATIVES
 // Legacy version of prepareShadingAttribs() without LOD bias
-void _fn prepareShadingAttribs(MaterialData material, in float3 P, in float3 camPos, in float3 normal, in float2 uv, _ref(ShadingAttribs) shAttr)
+void _fn prepareShadingAttribs<TMaterial:IMaterial>(TMaterial material, in float3 P, in float3 camPos, in float3 normal, in float2 uv, _ref(ShadingAttribs) shAttr)
 {
     prepareShadingAttribs(material, P, camPos, normal, uv, 0, shAttr);
 }
 
-void _fn prepareShadingAttribs(MaterialData material, in float3 P, in float3 camPos, in float3 normal, in float3 bitangent, in float2 uv, _ref(ShadingAttribs) shAttr)
+void _fn prepareShadingAttribs<TMaterial:IMaterial>(TMaterial material, in float3 P, in float3 camPos, in float3 normal, in float3 bitangent, in float2 uv, _ref(ShadingAttribs) shAttr)
 {
     prepareShadingAttribs(material, P, camPos, normal, bitangent, uv, 0, shAttr);
 }

--- a/Samples/Core/SimpleDeferred/Data/DeferredPass.ps.hlsl
+++ b/Samples/Core/SimpleDeferred/Data/DeferredPass.ps.hlsl
@@ -41,7 +41,8 @@ struct PS_OUT
 PS_OUT main(VS_OUT vOut)
 {
     ShadingAttribs shAttr;
-    prepareShadingAttribs(gMaterial, vOut.posW, gCam.position, vOut.normalW, vOut.texC, shAttr);
+    TMaterial mat = gMaterial;
+    prepareShadingAttribs(mat, vOut.posW, gCam.position, vOut.normalW, vOut.texC, shAttr);
 
     PS_OUT psOut;
     psOut.fragColor0 = float4(shAttr.P, 1);


### PR DESCRIPTION
Host side changes:

1. Moving RootSignature out of ProgramVersion class into ProgramKernels class

2. Creating root sinatures at `Program::createProgramKernels` instead of `ProgramVersion` creation.

3. Binding root signatures is no longer handled by `ProgramVars`, instead this is done in `RenderContext` or `ComputeContext` before draw or dispatch.

Shader changes:

1. declared a global generic type parameter `TMaterial` in `ShaderCommon.slang`
2. change type of `gMaterial` from `ParameterBlock<MaterialData>` to `ParameterBlock<TMaterial>`
3. change `prepareShadingAttribs` overloads to generic functions which take `TMaterial:IMaterial` as the first parameter, and call `IMaterial.prepare` function in their implementations.

After this change, the host code can compile unspecialized shader code and create `ProgramVersion`s, and do reflection on those. The engine now fails at generating program kernels because we are not providing the type arguments yet.