### PR TITLE
Host side refactoring for shader specialization

### DIFF
--- a/Framework/Source/Graphics/Material/Material.cpp
+++ b/Framework/Source/Graphics/Material/Material.cpp
@@ -313,7 +313,6 @@ namespace Falcor
         static const size_t dataSize = sizeof(MaterialDesc) + sizeof(MaterialValues);
         static_assert(dataSize % sizeof(glm::vec4) == 0, "Material::MaterialData size should be a multiple of 16");
 
-        auto offsett = pCB->getVariableOffset(std::string(varName) + "values.layers[0].albedo");
         check_offset(values.layers[0].albedo);
         check_offset(values.id);
         assert(offset + dataSize <= pCB->getSize());

--- a/Framework/Source/Graphics/Material/Material.cpp
+++ b/Framework/Source/Graphics/Material/Material.cpp
@@ -313,6 +313,7 @@ namespace Falcor
         static const size_t dataSize = sizeof(MaterialDesc) + sizeof(MaterialValues);
         static_assert(dataSize % sizeof(glm::vec4) == 0, "Material::MaterialData size should be a multiple of 16");
 
+        auto offsett = pCB->getVariableOffset(std::string(varName) + "values.layers[0].albedo");
         check_offset(values.layers[0].albedo);
         check_offset(values.id);
         assert(offset + dataSize <= pCB->getSize());
@@ -346,7 +347,7 @@ namespace Falcor
     {
         finalize();
         ConstantBuffer* pCB = pBlock->getConstantBuffer(pBlock->getReflection()->getName()).get();
-        setMaterialIntoBlockCommon(pBlock, pCB, 0, "", mData);
+        setMaterialIntoBlockCommon(pBlock, pCB, 0, "material.", mData);
     }
 
     void Material::setIntoProgramVars(ProgramVars* pVars, ConstantBuffer* pCb, const char varName[]) const
@@ -550,13 +551,26 @@ namespace Falcor
         return ParameterBlock::SharedConstPtr(mpParamBlock);
     }
 
+    ReflectionType::SharedPtr reflectType(slang::TypeLayoutReflection* pSlangType);
+
     void Material::createParameterBlock()
     {
+        // SLANG-INTEGRATION
+        // to create a parameter block for material,
+        // we only need to use reflection information from the `Material` shader struct type.
         if (spBlockReflection == nullptr)
         {
             GraphicsProgram::SharedPtr pProgram = GraphicsProgram::createFromFile("", "Framework/Shaders/MaterialBlock.slang");
             ProgramReflection::SharedConstPtr pReflection = pProgram->getActiveVersion()->getReflector();
-            spBlockReflection = pReflection->getParameterBlock(kMaterialVarName);
+            auto slangReq = pProgram->getActiveVersion()->slangRequest;
+            auto reflection = spGetReflection(slangReq);
+            auto materialType = spReflection_FindTypeByName(reflection, "Material");
+            auto layout = spReflection_GetTypeLayout(reflection, materialType, SLANG_LAYOUT_RULES_DEFAULT);
+            auto blockType = reflectType((slang::TypeLayoutReflection*)layout);
+            auto blockReflection = ParameterBlockReflection::create("");
+            blockReflection->setElementType(blockType);
+            blockReflection->finalize();
+            spBlockReflection = blockReflection;
             assert(spBlockReflection);
         }
         mpParamBlock = ParameterBlock::create(spBlockReflection, true);

--- a/Framework/Source/Graphics/Program/ParameterBlock.cpp
+++ b/Framework/Source/Graphics/Program/ParameterBlock.cpp
@@ -136,7 +136,17 @@ namespace Falcor
     }
 
     ParameterBlock::ParameterBlock(const ParameterBlockReflection::SharedConstPtr& pReflection, bool createBuffers) : mpReflector(pReflection)
-    {
+    {   
+        // SLANG-INTEGRATION
+        // when creating parameter blocks, we also store the element type of the parameter block
+        auto paramBlockType = pReflection->getType();
+        if (paramBlockType)
+        {
+            if (auto structType = paramBlockType->asStructType())
+                typeName = structType->getName();
+            else if (auto genericType = paramBlockType->asGenericType())
+                typeName = genericType->name;
+        }
         // Initialize the resource vectors
         const auto& setLayouts = pReflection->getDescriptorSetLayouts();
         mAssignedResources.resize(setLayouts.size());

--- a/Framework/Source/Graphics/Program/ParameterBlock.h
+++ b/Framework/Source/Graphics/Program/ParameterBlock.h
@@ -41,6 +41,10 @@ namespace Falcor
     class ParameterBlock : public std::enable_shared_from_this<ParameterBlock>
     {
     public:
+        // SLANG-INTEGRATION:
+        // A ParameterBlock should hold a type name of the shader component
+        std::string typeName;
+
         template<typename T>
         class SharedPtrT : public std::shared_ptr<T>
         {

--- a/Framework/Source/Graphics/Program/Program.h
+++ b/Framework/Source/Graphics/Program/Program.h
@@ -38,7 +38,7 @@ namespace Falcor
     class Shader;
     class RenderContext;
 
-    enum CompilePurpose
+    enum class CompilePurpose
     {
         ReflectionOnly, CodeGen
     };
@@ -233,7 +233,7 @@ namespace Falcor
 
         bool link() const;
 
-        SlangCompileRequest* createSlangCompileRequest(DefineList const& defines, CompilePurpose purpose) const;
+        SlangCompileRequest* createSlangCompileRequest(DefineList const& defines, CompilePurpose purpose, const std::vector<std::string> & typeArgs) const;
         int Program::doSlangCompilation(SlangCompileRequest* slangRequest, std::string& log) const;
 
         ProgramVersion::SharedPtr preprocessAndCreateProgramVersion(std::string& log) const;

--- a/Framework/Source/Graphics/Program/ProgramReflection.h
+++ b/Framework/Source/Graphics/Program/ProgramReflection.h
@@ -31,7 +31,7 @@
 #include <unordered_set>
 #include "Externals/Slang/slang.h"
 #include "API/DescriptorSet.h"
-
+#include <map>
 namespace Falcor
 {
     class ReflectionVar;
@@ -537,6 +537,12 @@ namespace Falcor
         */
         const std::string& getName() const { return mName; }
 
+        ReflectionType::SharedConstPtr mType;
+        const ReflectionType* getType() const
+        {
+            return mType.get();
+        }
+
         /** Check if the block contains any resources
         */
         bool isEmpty() const;
@@ -556,9 +562,9 @@ namespace Falcor
         /** Get a vector with the required descriptor-set layouts for the block. Useful when creating root-signatures
         */
         const SetLayoutVec& getDescriptorSetLayouts() const { return mSetLayouts; }
-    private:
         friend class ProgramReflection;
         void addResource(const ReflectionVar::SharedConstPtr& pVar);
+        void setElementType(const ReflectionType::SharedConstPtr& pType);
         void finalize();
         ParameterBlockReflection(const std::string& name);
         ResourceVec mResources;
@@ -577,6 +583,8 @@ namespace Falcor
         using SharedPtr = std::shared_ptr<ProgramReflection>;
         using SharedConstPtr = std::shared_ptr<const ProgramReflection>;
         static const uint32_t kInvalidLocation = -1;
+
+        std::map<std::string, uint32_t> typeParameterIndexMap;
 
         /** Data structured describing a shader input/output variable. Used mostly to communicate VS inputs and PS outputs
         */
@@ -636,6 +644,8 @@ namespace Falcor
         /** Get a pixel shader output variable
         */
         const ShaderVariable* getPixelShaderOutput(const std::string& name) const;
+
+        uint32_t getTypeParameterIndexByName(const std::string& name) const;
 
         /** Resource bind type
         */

--- a/Framework/Source/Graphics/Program/ProgramVersion.cpp
+++ b/Framework/Source/Graphics/Program/ProgramVersion.cpp
@@ -118,20 +118,23 @@ namespace Falcor
         std::shared_ptr<Program>     const& pProgram,
         DefineList                   const& defines,
         ProgramReflection::SharedPtr const& pReflector,
-        std::string                  const& name)
+        std::string                  const& name,
+        SlangCompileRequest * compileReq)
     {
-        return SharedPtr(new ProgramVersion(pProgram, defines, pReflector, name));
+        return SharedPtr(new ProgramVersion(pProgram, defines, pReflector, name, compileReq));
     }
 
     ProgramVersion::ProgramVersion(
         std::shared_ptr<Program>     const& pProgram,
         DefineList                   const& defines,
         ProgramReflection::SharedPtr const& pReflector,
-        std::string                  const& name)
+        std::string                  const& name,
+        SlangCompileRequest*         compileReq)
         : mpProgram(pProgram)
         , mDefines(defines)
         , mpReflector(pReflector)
         , mName(name)
+        , slangRequest(compileReq)
     {}
 
     ProgramKernels::SharedConstPtr ProgramVersion::getKernels(ProgramVars const* pVars) const

--- a/Framework/Source/Graphics/Program/ProgramVersion.h
+++ b/Framework/Source/Graphics/Program/ProgramVersion.h
@@ -133,13 +133,19 @@ namespace Falcor
         using SharedPtr = std::shared_ptr<ProgramVersion>;
         using SharedConstPtr = std::shared_ptr<const ProgramVersion>;
 
+        // SLANG-INTEGRATION:
+        // ProgramVersion now holds a SlangCompileRequest
+        // to support querying/creating new types and type layouts
+        // during ParameterBlock creation for shader components.
+        SlangCompileRequest* slangRequest = nullptr;
         using DefineList = Shader::DefineList;
 
         static SharedPtr create(
             std::shared_ptr<Program>     const& pProgram,
             DefineList                   const& defines,
             ProgramReflection::SharedPtr const& pReflector,
-            std::string                  const& name = "");
+            std::string                  const& name,
+            SlangCompileRequest * compileReq);
 
         /** Get the program that this version was created from
         */
@@ -166,7 +172,8 @@ namespace Falcor
             std::shared_ptr<Program>     const& pProgram,
             DefineList                   const& defines,
             ProgramReflection::SharedPtr const& pReflector,
-            std::string                  const& name);
+            std::string                  const& name,
+            SlangCompileRequest*         compileReq);
 
         std::shared_ptr<Program>        mpProgram;
         DefineList                      mDefines;


### PR DESCRIPTION
Host side refactoring for shader specialization

1.  `Material` class creates parameter block from the reflection information of the `Material` struct type, instead of the reflection information of a Program. This requires introducing new Slang API for querying a type from a CompileRequest, and creating a type layout for a given type on demand.

2. `Program::preprocessAndCreateProgramKernels` needs to extract type arguments from currently bound `ProgramVars`, this requires 1) querying the Type of parameter blocks that is being bound to a global generic parameter of the shader program; 2) quering the index of the associated global generic type; 3) write the type argument to an array at this index. 4) pass the type argument array to slang compiler via the `spAddEntryPointEx` function.