### PR TITLE
Make an interface for prepared material data

### DIFF
--- a/Framework/Source/Data/HostDeviceSharedCode.h
+++ b/Framework/Source/Data/HostDeviceSharedCode.h
@@ -165,42 +165,6 @@ struct MaterialData
     SamplerState samplerState;  // The sampler state to use when sampling the object
 };
 
-struct PreparedMaterialData
-{
-    MaterialDesc    desc;
-    MaterialValues  values;
-};
-
-/**
-    The structure stores the complete information about the shading point,
-    except for a light source information.
-    It stores pre-evaluated material parameters with pre-fetched textures,
-    shading point position, normal, viewing direction etc.
-*/
-struct ShadingAttribs
-{
-    float3    P;                                  ///< Shading hit position in world space
-    float3    E;                                  ///< Direction to the eye at shading hit
-    float3    N;                                  ///< Shading normal at shading hit
-    float3    T;                                  ///< Shading tangent at shading hit
-    float3    B;                                  ///< Shading bitangent at shading hit
-    float2    UV;                                 ///< Texture mapping coordinates
-
-#ifdef _MS_USER_DERIVATIVES
-    float2    DPDX            DEFAULTS(float2(0, 0));                                  
-    float2    DPDY            DEFAULTS(float2(0, 0)); ///< User-provided 2x2 full matrix of duv/dxy derivatives of a shading point footprint in texture space
-#else
-    float   lodBias         DEFAULTS(0);        ///< LOD bias to use when sampling textures
-#endif
-
-#ifdef _MS_USER_HALF_VECTOR_DERIVATIVES
-    float2    DHDX            DEFAULTS(float2(0, 0));
-    float2    DHDY            DEFAULTS(float2(0, 0));  ///< User-defined half-vector derivatives
-#endif
-    PreparedMaterialData preparedMat;               ///< Copy of the original material with evaluated parameters (i.e., textures are fetched etc.)
-    float aoFactor;
-};
-
 /*******************************************************************
                     Lights
 *******************************************************************/

--- a/Framework/Source/Data/ShaderCommon.slang
+++ b/Framework/Source/Data/ShaderCommon.slang
@@ -1,6 +1,8 @@
 
 __exported import ShaderCommonImpl;
 __import Shading;
-
+__import Interfaces;
 __generic_param TMaterial : IMaterial;
+//typedef TMaterial.EvaluatedMaterialValues ShadingAttribs;
+typedef ShadingAttribsImpl<PreparedMaterialData> ShadingAttribs;
 ParameterBlock<TMaterial> gMaterial;

--- a/Framework/Source/ShadingUtils/Helpers.slang
+++ b/Framework/Source/ShadingUtils/Helpers.slang
@@ -32,6 +32,7 @@
 // Make sure we get the macros like `_fn` and `_ref`
 // TODO: just eliminate these since we know this is pure Slang.
 #include "HostDeviceData.h"
+__import Interfaces;
 
 /*******************************************************************
 					Sampling functions
@@ -198,7 +199,7 @@ void _fn reflectFrame(float3 n, float3 reflect, _ref(float3) t, _ref(float3) b)
 					Texturing routines
 *******************************************************************/
 
-float4 _fn sampleTexture(Texture2D t, SamplerState s, ShadingAttribs attr)
+float4 _fn sampleTexture(Texture2D t, SamplerState s, ShadingGeometry attr)
 {
 #ifndef _MS_USER_DERIVATIVES
     return t.SampleBias(s, attr.UV, attr.lodBias);
@@ -207,7 +208,7 @@ float4 _fn sampleTexture(Texture2D t, SamplerState s, ShadingAttribs attr)
 #endif
 }
 
-float4 _fn sampleTexture(Texture2DArray t, SamplerState s, ShadingAttribs attr, int arrayIndex)
+float4 _fn sampleTexture(Texture2DArray t, SamplerState s, ShadingGeometry attr, int arrayIndex)
 {
 #ifndef _MS_USER_DERIVATIVES
     return t.SampleBias(s, float3(attr.UV, arrayIndex), attr.lodBias);
@@ -216,7 +217,7 @@ float4 _fn sampleTexture(Texture2DArray t, SamplerState s, ShadingAttribs attr, 
 #endif
 }
 
-float4 _fn evalTex(in uint32_t hasTexture, Texture2D tex, SamplerState s, ShadingAttribs attr, in float4 defaultValue)
+float4 _fn evalTex(in uint32_t hasTexture, Texture2D tex, SamplerState s, ShadingGeometry attr, in float4 defaultValue)
 {
 #ifndef _MS_DISABLE_TEXTURES
 	if(hasTexture != 0)
@@ -228,7 +229,7 @@ float4 _fn evalTex(in uint32_t hasTexture, Texture2D tex, SamplerState s, Shadin
 	return defaultValue;
 }
 
-float4 _fn evalWithColor(in uint32_t hasTexture, Texture2D tex, SamplerState s, float4 color, ShadingAttribs attr)
+float4 _fn evalWithColor(in uint32_t hasTexture, Texture2D tex, SamplerState s, float4 color, ShadingGeometry attr)
 {
 	return evalTex(hasTexture, tex, s, attr, color);
 }
@@ -267,7 +268,7 @@ void _fn applyNormalMap(in float3 texValue, _ref(float3) n, _ref(float3) t, _ref
 }
 
 #ifndef _MS_LEAN_MAPPING
-void _fn perturbNormal(MaterialData mat, _ref(ShadingAttribs) attr, bool forceSample)
+void _fn perturbNormal(MaterialData mat, _ref(ShadingGeometry) attr, bool forceSample)
 {
 	if(forceSample || mat.desc.hasNormalMap != 0)
 	{
@@ -276,7 +277,7 @@ void _fn perturbNormal(MaterialData mat, _ref(ShadingAttribs) attr, bool forceSa
 	}
 }
 #else
-void applyLeanMap(in Texture2D leanMap, in SamplerState samplerState, inout ShadingAttribs shAttr)
+void applyLeanMap(in Texture2D leanMap, in SamplerState samplerState, inout ShadingGeometry shAttr)
 {
     float4 t = sampleTexture(leanMap, samplerState, shAttr);
     // Reconstruct B 
@@ -321,7 +322,7 @@ void applyLeanMap(in Texture2D leanMap, in SamplerState samplerState, inout Shad
 #endif
 }
 
-void perturbNormal(MaterialData mat, inout ShadingAttribs shAttr, bool forceSample)
+void perturbNormal(MaterialData mat, inout ShadingGeometry shAttr, bool forceSample)
 {
     if (mat.desc.hasNormalMap != 0)
     {
@@ -331,7 +332,7 @@ void perturbNormal(MaterialData mat, inout ShadingAttribs shAttr, bool forceSamp
 #endif
 
 // Note: explicit overload instead of default argument, at least until cross-compiler can handle defaults
-void _fn perturbNormal(MaterialData mat, _ref(ShadingAttribs) attr)
+void _fn perturbNormal(MaterialData mat, _ref(ShadingGeometry) attr)
 {
 	perturbNormal(mat, attr, false);
 }
@@ -346,7 +347,7 @@ bool _fn alphaTestEnabled(MaterialData mat)
     return mat.desc.hasAlphaMap != 0;
 }
 
-bool _fn alphaTestPassed(MaterialData mat, ShadingAttribs attr)
+bool _fn alphaTestPassed(MaterialData mat, ShadingGeometry attr)
 {
 #ifndef _MS_DISABLE_ALPHA_TEST
     if(sampleTexture(mat.textures.alphaMap, mat.samplerState, attr).x < mat.values.alphaThreshold)
@@ -355,7 +356,7 @@ bool _fn alphaTestPassed(MaterialData mat, ShadingAttribs attr)
     return true;
 }
 
-void _fn basicAlphaTest(MaterialData mat, ShadingAttribs attr)
+void _fn basicAlphaTest(MaterialData mat, ShadingGeometry attr)
 {
 #ifndef _MS_DISABLE_ALPHA_TEST
     if(alphaTestEnabled(mat))
@@ -370,7 +371,7 @@ void _fn basicAlphaTest(MaterialData mat, ShadingAttribs attr)
                     Hashed Alpha Test
 *******************************************************************/
 
-bool _fn hashedAlphaTestPassed(MaterialData mat, ShadingAttribs attr, float alphaThreshold)
+bool _fn hashedAlphaTestPassed(MaterialData mat, ShadingGeometry attr, float alphaThreshold)
 {
     float compareTo = alphaThreshold <= 0 ? mat.values.alphaThreshold : clamp(alphaThreshold, 0.0f, 1.0f);
 #ifndef _MS_DISABLE_ALPHA_TEST
@@ -380,7 +381,7 @@ bool _fn hashedAlphaTestPassed(MaterialData mat, ShadingAttribs attr, float alph
     return true;
 }
 
-void _fn applyHashedAlphaTest(MaterialData mat, ShadingAttribs attr, float alphaThreshold)
+void _fn applyHashedAlphaTest(MaterialData mat, ShadingGeometry attr, float alphaThreshold)
 {
 #ifndef _MS_DISABLE_ALPHA_TEST
     if (alphaTestEnabled(mat))
@@ -470,7 +471,7 @@ float _fn calculateHashedAlpha(float3 hashInputCoord, float hashScale, bool useA
 /*******************************************************************
     alpha test
 *******************************************************************/    
-void _fn applyAlphaTest(MaterialData material, ShadingAttribs shAttr, float3 posW)
+void _fn applyAlphaTest(MaterialData material, ShadingGeometry shAttr, float3 posW)
 {
     float hashedAlphaScale = 1.0f;
 #ifdef _HASHED_ALPHA_SCALE

--- a/Framework/Source/ShadingUtils/Interfaces.slang
+++ b/Framework/Source/ShadingUtils/Interfaces.slang
@@ -1,0 +1,55 @@
+#include "HostDeviceData.h"
+
+// SLANG-INTEGRATION: move ShadingAttribs from HostDeviceData.h to Shading.slang
+// Rename ShadingAttribs to ShadingAttribsImpl,
+// ShadingAttribsImpl now becomes a generic type 
+// (features a generic type parameter for the prepared material field)
+// Original ShadingAttribs now maps to ShadingAttribsImpl<TMaterial.EvaluatedMaterial>
+
+/**
+    The structure stores the complete information about the shading point,
+    except for a light source information.
+    It stores pre-evaluated material parameters with pre-fetched textures,
+    shading point position, normal, viewing direction etc.
+*/
+
+// SLANG-INTEGRATION: move all geometry attributes to ShadingGeometry type.
+struct ShadingGeometry
+{
+    float3    P;                                  ///< Shading hit position in world space
+    float3    E;                                  ///< Direction to the eye at shading hit
+    float3    N;                                  ///< Shading normal at shading hit
+    float3    T;                                  ///< Shading tangent at shading hit
+    float3    B;                                  ///< Shading bitangent at shading hit
+    float2    UV;                                 ///< Texture mapping coordinates
+
+#ifdef _MS_USER_DERIVATIVES
+    float2    DPDX            DEFAULTS(float2(0, 0));                                  
+    float2    DPDY            DEFAULTS(float2(0, 0)); ///< User-provided 2x2 full matrix of duv/dxy derivatives of a shading point footprint in texture space
+#else
+    float   lodBias         DEFAULTS(0);        ///< LOD bias to use when sampling textures
+#endif
+
+#ifdef _MS_USER_HALF_VECTOR_DERIVATIVES
+    float2    DHDX            DEFAULTS(float2(0, 0));
+    float2    DHDY            DEFAULTS(float2(0, 0));  ///< User-defined half-vector derivatives
+#endif
+};
+
+// SLANG-INTEGRATION: 
+// original ShadingAttribs now becomes ShadingAttribsImpl, which contains two fields:
+// geom field for all the geometry attributes, and preparedMat for the evaluated material values
+
+struct ShadingAttribsImpl<TEvaluatedMaterial>
+{
+    ShadingGeometry geom;
+    TEvaluatedMaterial preparedMat;   ///< Copy of the original material with evaluated parameters (i.e., textures are fetched etc.)
+};
+
+ShadingAttribsImpl<TEvaluatedMaterial> makeShadingAttribs<TEvaluatedMaterial>(ShadingGeometry geom, TEvaluatedMaterial mat)
+{
+    ShadingAttribsImpl<TEvaluatedMaterial> rs;
+    rs.geom = geom;
+    rs.preparedMat = mat;
+    return rs;
+}

--- a/Framework/Source/ShadingUtils/Lights.slang
+++ b/Framework/Source/ShadingUtils/Lights.slang
@@ -30,6 +30,7 @@
 #define _FALCOR_LIGHTS_H_
 
 __import Helpers;
+__import Interfaces;
 
 // Make sure we get the macros like `_fn` and `_ref`
 // TODO: just eliminate these since we know this is pure Slang.
@@ -96,7 +97,7 @@ inline float3 _fn getLightRadiance(LightData Light, float3 shadingPosition)
     The outputs are an incident radiance towards the shading point 
     and the direction from the shading point towards the light source.
 */
-inline void _fn prepareLightAttribs(LightData Light, ShadingAttribs ShAttr, float shadowFactor, _ref(LightAttribs) LightAttr)
+inline void _fn prepareLightAttribs(LightData Light, ShadingGeometry ShAttr, float shadowFactor, _ref(LightAttribs) LightAttr)
 {
     /* Evaluate direction to the light */
     LightAttr.P = getLightPos(Light, ShAttr.P);

--- a/Framework/Source/ShadingUtils/Shading.slang
+++ b/Framework/Source/ShadingUtils/Shading.slang
@@ -34,11 +34,7 @@
 #include "HostDeviceData.h"
 
 __import Helpers;
-
-interface IMaterial
-{
-    void prepare(inout ShadingAttribs shAttrib);
-}
+__import Interfaces;
 
 /*******************************************************************
 Documentation
@@ -93,6 +89,35 @@ struct ShadingOutput
     float2  effectiveRoughness;     ///< Sampled brdf roughness, or for evaluated material, an effective roughness
 };
 
+// SLANG-INTEGRATION: define interfaces
+
+interface IBRDF
+{
+    void eval(ShadingGeometry geom, LightAttribs lAttr, inout ShadingOutput result);
+}
+
+interface IMaterial
+{
+    //associatedtype EvaluatedMaterialValues;
+
+    ShadingAttribsImpl<PreparedMaterialData> prepare(ShadingGeometry geom);
+}
+
+ShadingOutput initShadingOutput()
+{
+    ShadingOutput result;
+    result.diffuseAlbedo = 0;
+    result.diffuseIllumination = 0;
+    result.specularAlbedo = 0;
+    result.specularIllumination = 0;
+    result.finalValue = 0;
+    result.effectiveRoughness = 0;
+    result.wi = 0;
+    result.pdf = 0;
+    result.thp = 0;
+    return result;
+}
+
 /* Include all shading routines, including endpoints (camera and light) */
 
 __import Cameras;
@@ -103,12 +128,60 @@ __import BSDFs;
 Material shading building blocks
 *******************************************************************/
 
+struct PreparedMaterialData : IBRDF
+{
+    MaterialDesc    desc;
+    MaterialValues  values;
+    
+    // SLANG-INTEGRATION: move aoFactor from ShadingAttribs to PreparedMaterialData
+    float aoFactor;
+
+
+    // SLANG-INTEGRATION: PreparedMaterialData now implements IBRDF interface
+
+    void eval(ShadingGeometry geom, LightAttribs lAttr, inout ShadingOutput result)
+    {
+        // call previous evalMaterial (now evalDefaultMaterial) function 
+        ShadingAttribsImpl<PreparedMaterialData> shAttr = makeShadingAttribs(geom, this);
+        evalDefaultMaterial(shAttr, lAttr, result, false);
+    }
+};
+
+ShadingGeometry prepareShadingGeometry(float3 P, float3 camPos, 
+        float3 normal, float3 bitangent, float2 uv,
+        #ifdef _MS_USER_DERIVATIVES
+            float2 dPdx, float2 dPdy,
+        #else
+            float lodBias,
+        #endif
+    )
+{
+    /* Prepare shading geometry attributes */
+    ShadingGeometry geom;
+    geom.P = P;
+    geom.E = normalize(camPos - P);
+    geom.N = normalize(normal);
+    geom.B = normalize(bitangent - geom.N * (dot(bitangent, geom.N)));
+    geom.T = normalize(cross(geom.B, geom.N));
+    geom.UV = uv;
+    #ifdef _MS_USER_DERIVATIVES
+        geom.DPDX = dPdx;
+        geom.DPDY = dPdy;
+    #else
+        geom.lodBias = lodBias;
+    #endif
+    return geom;
+}
+
 struct Material : IMaterial
 {
     MaterialData materialData;
 
-    void prepare(inout ShadingAttribs shAttr)
+    ShadingAttribsImpl<PreparedMaterialData> prepare(ShadingGeometry geom)
     {
+        ShadingAttribsImpl<PreparedMaterialData> shAttr;
+        shAttr.geom = geom;
+
         /* Copy the input material parameters */
 #ifdef _MS_STATIC_MATERIAL_DESC
         MaterialDesc desc = _MS_STATIC_MATERIAL_DESC;
@@ -120,8 +193,8 @@ struct Material : IMaterial
         shAttr.preparedMat.desc = desc;
 
         /* Evaluate alpha test material modifier */
-        applyAlphaTest(materialData, shAttr, shAttr.P);
-        shAttr.aoFactor = 1;
+        applyAlphaTest(materialData, shAttr.geom, shAttr.geom.P);
+        shAttr.preparedMat.aoFactor = 1;
 
         bool done = false;
         $for(iLayer in Range(0, MatMaxLayers))
@@ -134,12 +207,13 @@ struct Material : IMaterial
                 shAttr.preparedMat.values.layers[iLayer].albedo =
                     evalWithColor(desc.layers[iLayer].hasTexture, 
                     materialData.textures.layers[iLayer], materialData.samplerState, 
-                    materialData.values.layers[iLayer].albedo, shAttr);
+                    materialData.values.layers[iLayer].albedo, shAttr.geom);
             }
         }
 
         /* Perturb shading normal is needed */
-        perturbNormal(materialData, shAttr);
+        perturbNormal(materialData, shAttr.geom);
+        return shAttr;
     }
 };
 
@@ -157,23 +231,16 @@ void prepareShadingAttribs<TMaterial:IMaterial>(TMaterial material, in float3 P,
 #else
     float lodBias,
 #endif
-    _ref(ShadingAttribs) shAttr)
+    _ref(ShadingAttribsImpl<PreparedMaterialData>) shAttr)
 {
-    /* Prepare shading attributes */
-    shAttr.P = P;
-    shAttr.E = normalize(camPos - P);
-    shAttr.N = normalize(normal);
-    shAttr.B = normalize(bitangent - shAttr.N * (dot(bitangent, shAttr.N)));
-    shAttr.T = normalize(cross(shAttr.B, shAttr.N));
-    shAttr.UV = uv;
-#ifdef _MS_USER_DERIVATIVES
-    shAttr.DPDX = dPdx;
-    shAttr.DPDY = dPdy;
-#else
-    shAttr.lodBias = lodBias;
-#endif
-
-    material.prepare(shAttr);
+    ShadingGeometry geom = prepareShadingGeometry(P, camPos, normal, bitangent, uv,
+    #ifdef _MS_USER_DERIVATIVES
+        dPdx, dPdy,
+    #else
+        lodBias
+    #endif
+    );
+    shAttr = material.prepare(geom);
 }
 
 /**
@@ -187,7 +254,7 @@ void _fn prepareShadingAttribs<TMaterial:IMaterial>(TMaterial material, in float
 #else
     float lodBias,
 #endif
-    _ref(ShadingAttribs) shAttr)
+    _ref(ShadingAttribsImpl<PreparedMaterialData>) shAttr)
 {
     /* Generate an axis-aligned tangent frame */
     float3 bitangent;
@@ -204,12 +271,16 @@ void _fn prepareShadingAttribs<TMaterial:IMaterial>(TMaterial material, in float
 
 #ifndef _MS_USER_DERIVATIVES
 // Legacy version of prepareShadingAttribs() without LOD bias
-void _fn prepareShadingAttribs<TMaterial:IMaterial>(TMaterial material, in float3 P, in float3 camPos, in float3 normal, in float2 uv, _ref(ShadingAttribs) shAttr)
+void _fn prepareShadingAttribs<TMaterial:IMaterial>(TMaterial material, in float3 P, 
+    in float3 camPos, in float3 normal, in float2 uv, 
+    _ref(ShadingAttribsImpl<PreparedMaterialData>) shAttr)
 {
     prepareShadingAttribs(material, P, camPos, normal, uv, 0, shAttr);
 }
 
-void _fn prepareShadingAttribs<TMaterial:IMaterial>(TMaterial material, in float3 P, in float3 camPos, in float3 normal, in float3 bitangent, in float2 uv, _ref(ShadingAttribs) shAttr)
+void _fn prepareShadingAttribs<TMaterial:IMaterial>(TMaterial material, in float3 P, 
+    in float3 camPos, in float3 normal, in float3 bitangent, in float2 uv, 
+    _ref(ShadingAttribsImpl<PreparedMaterialData>) shAttr)
 {
     prepareShadingAttribs(material, P, camPos, normal, bitangent, uv, 0, shAttr);
 }
@@ -241,7 +312,7 @@ float4 _fn evalDiffuseLayer(MaterialLayerValues layer, float3 lightIntensity, fl
 
 // Implementation of NDF filtering code from the HPG'16 submission
 // The writeup is here: //research/graphics/projects/halfvectorSpace/SAA/paper/specaa-sub.pdf
-float2 _fn filterRoughness(ShadingAttribs shAttr, LightAttribs lAttr, in float2 roughness)
+float2 _fn filterRoughness(ShadingGeometry shAttr, LightAttribs lAttr, in float2 roughness)
 {
 #ifdef _MS_USER_HALF_VECTOR_DERIVATIVES
     float2  hppDx = shAttr.DHDX;
@@ -268,7 +339,7 @@ float2 _fn filterRoughness(ShadingAttribs shAttr, LightAttribs lAttr, in float2 
     return roughness;
 }
 
-float4 _fn evalSpecularLayer(MaterialLayerDesc desc, MaterialLayerValues data, ShadingAttribs shAttr, LightAttribs lAttr, _ref(PassOutput) result)
+float4 _fn evalSpecularLayer(MaterialLayerDesc desc, MaterialLayerValues data, ShadingGeometry shAttr, LightAttribs lAttr, _ref(PassOutput) result)
 {
 #ifndef _MS_DISABLE_SPECULAR
     /* Add albedo regardless of facing */
@@ -374,7 +445,7 @@ The routine takes a layer index, as well as shading attributes, including prepar
 it also takes prepared attributes of a light source, such as incident radiance and a world-space direction to the light.
 The output is the illumination of the current layer, blended into the results of the previous layers with a specified blending mode.
 */
-void _fn evalMaterialLayer(int iLayer, ShadingAttribs attr, LightAttribs lAttr,
+void _fn evalMaterialLayer(int iLayer, ShadingAttribsImpl<PreparedMaterialData> attr, LightAttribs lAttr,
     _ref(PassOutput) result)
 {
     float4 value = 0;
@@ -384,14 +455,14 @@ void _fn evalMaterialLayer(int iLayer, ShadingAttribs attr, LightAttribs lAttr,
     switch(desc.type)
     {
     case MatLambert: /* Diffuse BRDF */
-        value = evalDiffuseLayer(values, lAttr.lightIntensity, lAttr.L, attr.N, result) * lAttr.shadowFactor;
+        value = evalDiffuseLayer(values, lAttr.lightIntensity, lAttr.L, attr.geom.N, result) * lAttr.shadowFactor;
         break;
     case MatEmissive:
         value = evalEmissiveLayer(values, result);
         break;
     case MatConductor:
     case MatDielectric:
-        value = evalSpecularLayer(desc, values, attr, lAttr, result) * lAttr.shadowFactor;
+        value = evalSpecularLayer(desc, values, attr.geom, lAttr, result) * lAttr.shadowFactor;
         break;
     };
 
@@ -402,13 +473,29 @@ void _fn evalMaterialLayer(int iLayer, ShadingAttribs attr, LightAttribs lAttr,
     result.effectiveRoughness += result.roughness * delta;
 }
 
+// SLANG-INTEGRATION: evalMaterial function now becomes a generic function that
+// calls the IBRDF.eval() method
+void evalMaterial<TBRDF : IBRDF>(
+    ShadingAttribsImpl<TBRDF> shAttr,
+    LightAttribs lAttr,
+    _ref(ShadingOutput) result,
+    bool initializeShadingOut DEFAULTS(false))
+{
+    if (initializeShadingOut)
+        result = initShadingOutput();
+    shAttr.preparedMat.eval(shAttr.geom, lAttr, result);
+}
+
+// SLANG-INTEGRATION: rename all evalMaterial functions to evalDefaultMaterial
+// and these functions takes renamed ShadingAttribs (now ShadingAttribsImpl<PreparedMaterialData>)
+// as its argument
 
 /**	The highest-level material evaluation function.
 This is the main routing for evaluating a complete PBR material, given a shading point and a light source.
 Should be called once per light.
 */
-void _fn evalMaterial(
-    ShadingAttribs shAttr,
+void _fn evalDefaultMaterial(
+    ShadingAttribsImpl<PreparedMaterialData> shAttr,
     LightAttribs lAttr,
     _ref(ShadingOutput) result,
     bool initializeShadingOut DEFAULTS(false))
@@ -465,8 +552,8 @@ void _fn evalMaterial(
     result.specularAlbedo = passResult.specularAlbedo;
 }
 
-void _fn evalMaterial(
-    ShadingAttribs shAttr,
+void _fn evalMaterial<TBRDF : IBRDF>(
+    ShadingAttribsImpl<TBRDF> shAttr,
     LightData light,
     float shadowFactor,
     _ref(ShadingOutput) result,
@@ -474,7 +561,7 @@ void _fn evalMaterial(
 {
     /* Prepare lighting attributes */
     LightAttribs LAttr;
-    prepareLightAttribs(light, shAttr, shadowFactor, LAttr);
+    prepareLightAttribs(light, shAttr.geom, shadowFactor, LAttr);
 
     /* Evaluate material with lighting attributes */
     evalMaterial(shAttr, LAttr, result, initializeShadingOut);
@@ -483,8 +570,8 @@ void _fn evalMaterial(
 /**
 Another overload of material evaluation function, which prepares light attributes internally.
 */
-void _fn evalMaterial(
-    ShadingAttribs shAttr,
+void _fn evalMaterial<TBRDF : IBRDF>(
+    ShadingAttribsImpl<TBRDF> shAttr,
     LightData light,
     _ref(ShadingOutput) result,
     bool initializeShadingOut DEFAULTS(false))
@@ -578,7 +665,7 @@ Tries to find a diffuse albedo color for a given material
 \param[in] Material Material to look in
 returns black if the layer is not found, diffuse albedo color otherwise
 */
-float4 _fn getDiffuseColor(ShadingAttribs shAttr)
+float4 _fn getDiffuseColor(ShadingAttribsImpl<PreparedMaterialData> shAttr)
 {
     float4 ret = 0;
     // This is here because the HLSL compiler complains about 'data' not being completely initialized when used
@@ -598,7 +685,7 @@ Tries to override a diffuse albedo color for all layers within a given material
 \param[in] Material Material to look in
 returns true if succeeded
 */
-bool _fn overrideDiffuseColor(_ref(ShadingAttribs) shAttr, float4 albedo, bool allLayers = true)
+bool _fn overrideDiffuseColor(_ref(ShadingAttribsImpl<PreparedMaterialData>) shAttr, float4 albedo, bool allLayers = true)
 {
     bool found = false;
     if(!allLayers)
@@ -631,7 +718,7 @@ Tries to find a specular albedo color for a given material
 \param[in] material Material to look in
 returns black if the layer is not found, specular color otherwise
 */
-float4 _fn getSpecularColor(ShadingAttribs shAttr)
+float4 _fn getSpecularColor(ShadingAttribsImpl<PreparedMaterialData> shAttr)
 {
     float4 ret = 0;
     MaterialLayerValues data;
@@ -652,7 +739,7 @@ float4 _fn getSpecularColor(ShadingAttribs shAttr)
     \param[out] result Gather incident direction, probability density function, and path throughput
 */
 void _fn sampleMaterial(
-    ShadingAttribs shAttr,
+    ShadingAttribsImpl<PreparedMaterialData> shAttr,
     in float2 rSample,
     _ref(ShadingOutput) result)
 {
@@ -677,7 +764,7 @@ void _fn sampleMaterial(
             sampleDiffuse = false;
 
             float3 m;
-            float3 wo = toLocal(shAttr.E, shAttr.T, shAttr.B, shAttr.N);
+            float3 wo = toLocal(shAttr.geom.E, shAttr.geom.T, shAttr.geom.B, shAttr.geom.N);
             float2 roughness = float2(specData.roughness.x, specData.roughness.y);
 
             // Set the specular reflectivity
@@ -702,13 +789,13 @@ void _fn sampleMaterial(
 
             // Convert direction vector from local to global frame
             // global space coordinates
-            result.wi = fromLocal(result.wi, shAttr.T, shAttr.B, shAttr.N);
+            result.wi = fromLocal(result.wi, shAttr.geom.T, shAttr.geom.B, shAttr.geom.N);
 
             // Evaluate standard microfacet model terms
-            result.thp *= evalMicrofacetTerms(shAttr.T, shAttr.B, shAttr.N, m, shAttr.E, result.wi, roughness, specDesc.ndf, (specDesc.type) == MatDielectric);
+            result.thp *= evalMicrofacetTerms(shAttr.geom.T, shAttr.geom.B, shAttr.geom.N, m, shAttr.geom.E, result.wi, roughness, specDesc.ndf, (specDesc.type) == MatDielectric);
 
             // Fresnel conductor/dielectric term
-            float HoE = dot(m, shAttr.E);
+            float HoE = dot(m, shAttr.geom.E);
             float IoR = specData.extraParam.x;
             float kappa = specData.extraParam.y;
             float F_term = (specDesc.type == MatConductor) ? conductorFresnel(HoE, IoR, kappa) : 1.f - dielectricFresnel(HoE, IoR);
@@ -732,7 +819,7 @@ void _fn sampleMaterial(
 
         // Convert direction vector from local to global frame
         // global space coordinates
-        result.wi = fromLocal(result.wi, shAttr.T, shAttr.B, shAttr.N);
+        result.wi = fromLocal(result.wi, shAttr.geom.T, shAttr.geom.B, shAttr.geom.N);
 
         // Ideally thp = (\rho / \pi) * |\omega_i . n| / bsdfPdf
         // By importance sampling the cosine lobe, we can set bsdfPdf = |\omega_i . n| / \pi

--- a/Samples/Core/SimpleDeferred/Data/DeferredPass.ps.hlsl
+++ b/Samples/Core/SimpleDeferred/Data/DeferredPass.ps.hlsl
@@ -45,8 +45,8 @@ PS_OUT main(VS_OUT vOut)
     prepareShadingAttribs(mat, vOut.posW, gCam.position, vOut.normalW, vOut.texC, shAttr);
 
     PS_OUT psOut;
-    psOut.fragColor0 = float4(shAttr.P, 1);
-    psOut.fragColor1 = float4(shAttr.N, 1);
+    psOut.fragColor0 = float4(shAttr.geom.P, 1);
+    psOut.fragColor1 = float4(shAttr.geom.N, 1);
     psOut.fragColor2 = shAttr.preparedMat.values.layers[0].albedo;
 
     return psOut;

--- a/Samples/Core/SimpleDeferred/Data/LightingPass.ps.hlsl
+++ b/Samples/Core/SimpleDeferred/Data/LightingPass.ps.hlsl
@@ -27,19 +27,13 @@
 ***************************************************************************/
 __import ShaderCommonImpl;
 __import Shading;
+__import LightingPassCommon;
 
 cbuffer PerImageCB
 {
-    // G-Buffer
-    // Lighting params
-	LightData gDirLight;
-	LightData gPointLight;
-	float3 gAmbient;
-    // Debug mode
-	uint gDebugMode;
+    LightingPassParams params;
 };
 
-#include "LightingPassCommon.h"
 
 Texture2D gGBuf0;
 Texture2D gGBuf1;
@@ -52,7 +46,7 @@ float4 main(float2 texC : TEXCOORD, float4 pos : SV_POSITION) : SV_TARGET
     const float3 normalW = gGBuf1.Load(int3(pos.xy, 0)).rgb;
     const float4 albedo  = gGBuf2.Load(int3(pos.xy, 0));
 
-    float3 color = shade(posW, normalW, albedo);
+    float3 color = shade(params, posW, normalW, albedo);
 
 	return float4(color, 1);
 }

--- a/Samples/Core/SimpleDeferred/Data/LightingPassCommon.slang
+++ b/Samples/Core/SimpleDeferred/Data/LightingPassCommon.slang
@@ -26,6 +26,10 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 ***************************************************************************/
 
+__import ShaderCommonImpl;
+__import Shading;
+__import Interfaces;
+
 // Debug modes
 #define ShowPos         1
 #define ShowNormals     2
@@ -38,7 +42,18 @@
 #define vec4 float4
 #endif
 
-vec3 shade(vec3 posW, vec3 normalW, vec4 albedo)
+struct LightingPassParams
+{
+    // G-Buffer
+    // Lighting params
+	LightData gDirLight;
+	LightData gPointLight;
+	float3 gAmbient;
+    // Debug mode
+	uint gDebugMode;
+};
+
+vec3 shade(LightingPassParams params, vec3 posW, vec3 normalW, vec4 albedo)
 {
     // Discard empty pixels
     if (albedo.a <= 0)
@@ -47,10 +62,10 @@ vec3 shade(vec3 posW, vec3 normalW, vec4 albedo)
     }
 
     /* Reconstruct shading attributes */
-    ShadingAttribs shAttr;
-    shAttr.P = posW;
-    shAttr.E = normalize(gCam.position - posW);
-    shAttr.N = normalW;
+    ShadingAttribsImpl<PreparedMaterialData> shAttr;
+    shAttr.geom.P = posW;
+    shAttr.geom.E = normalize(gCam.position - posW);
+    shAttr.geom.N = normalW;
 
     /* Reconstruct layers (one diffuse layer) */
     initDiffuseLayer(shAttr.preparedMat.desc.layers[0], shAttr.preparedMat.values.layers[0], albedo.rgb);
@@ -59,21 +74,21 @@ vec3 shade(vec3 posW, vec3 normalW, vec4 albedo)
     /* Do lighting */
     ShadingOutput result;
     // Directional light
-    evalMaterial(shAttr, gDirLight, result, true);
+    evalMaterial(shAttr, params.gDirLight, result, true);
     // Point light
-    evalMaterial(shAttr, gPointLight, result, false);
+    evalMaterial(shAttr, params.gPointLight, result, false);
     // Add ambient term
-    result.finalValue += gAmbient * result.diffuseAlbedo;
-    result.diffuseIllumination += gAmbient;
+    result.finalValue += params.gAmbient * result.diffuseAlbedo;
+    result.diffuseIllumination += params.gAmbient;
 
     // Debug vis
-    if (gDebugMode != 0)
+    if (params.gDebugMode != 0)
     {
-        if (gDebugMode == ShowPos)
+        if (params.gDebugMode == ShowPos)
             result.finalValue = posW;
-        else if (gDebugMode == ShowNormals)
+        else if (params.gDebugMode == ShowNormals)
             result.finalValue = 0.5 * normalW + 0.5f;
-        else if (gDebugMode == ShowAlbedo)
+        else if (params.gDebugMode == ShowAlbedo)
             result.finalValue = albedo.rgb;
         else
             result.finalValue = result.diffuseIllumination;

--- a/Samples/Core/SimpleDeferred/SimpleDeferred.cpp
+++ b/Samples/Core/SimpleDeferred/SimpleDeferred.cpp
@@ -266,11 +266,11 @@ void SimpleDeferred::onFrameRender()
 
         // Set lighting params
         ConstantBuffer::SharedPtr pLightCB = mpLightingVars["PerImageCB"];
-        pLightCB["gAmbient"] = mAmbientIntensity;
-        mpDirLight->setIntoConstantBuffer(pLightCB.get(), "gDirLight");
-        mpPointLight->setIntoConstantBuffer(pLightCB.get(), "gPointLight");
+        pLightCB["params.gAmbient"] = mAmbientIntensity;
+        mpDirLight->setIntoConstantBuffer(pLightCB.get(), "params.gDirLight");
+        mpPointLight->setIntoConstantBuffer(pLightCB.get(), "params.gPointLight");
         // Debug mode
-        pLightCB->setVariable("gDebugMode", (uint32_t)mDebugMode);
+        pLightCB->setVariable("params.gDebugMode", (uint32_t)mDebugMode);
 
         // Set GBuffer as input
         mpLightingVars->setTexture("gGBuf0", mpGBufferFbo->getColorTexture(0));

--- a/Samples/Core/SimpleDeferred/SimpleDeferred.vcxproj
+++ b/Samples/Core/SimpleDeferred/SimpleDeferred.vcxproj
@@ -14,7 +14,7 @@
     <ClCompile Include="SimpleDeferred.cpp" />
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="Data\LightingPassCommon.h" />
+    <ClInclude Include="Data\LightingPassCommon.slang" />
     <ClInclude Include="SimpleDeferred.h" />
   </ItemGroup>
   <ItemGroup>

--- a/Samples/Core/SimpleDeferred/SimpleDeferred.vcxproj.filters
+++ b/Samples/Core/SimpleDeferred/SimpleDeferred.vcxproj.filters
@@ -24,7 +24,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="SimpleDeferred.h" />
-    <ClInclude Include="Data\LightingPassCommon.h">
+    <ClInclude Include="Data\LightingPassCommon.slang">
       <Filter>Data</Filter>
     </ClInclude>
   </ItemGroup>


### PR DESCRIPTION
This is the first step of generalizing the material system. Different `TMaterial`s should evaluate different terms during prepare phase. This commits adds a IBRDF interface to represent the prepared material values. Existing PreparedMaterialData is the first implementation to the IBRDF interface.

This commit include the following changes:

1. Add `IBRDF` interface for the prepared material data. (Shading.slang)
2. Cleanup `ShadingAttribs`. Currently `ShadingAttribs` is a coupled struct type that serves for two different purposes:
    1) stores the "geometry` terms of the shading point (e.g. position, normal, tangent, uv, etc.);
    2) stores the prepared material data. Many helper and lighting functions defined in `Helpers.slang`. 

`Shading.slang`  and `Lights.slang` are only using the geometry terms and independent on the prepared material data. As a cleanup step, we created a new struct type `ShadingGeometry`, to encapsulate all the geometry terms, and for the helper functions that depends only the geometry terms, we change its parameter type to `ShadingGemetry` instead of `ShadingAttribs`. The new `ShadingAttribs` type becomes a generic `ShadingAttribsImpl<TBRDF>` type, which encapsulates both a `ShadingGeometry` field and a `TBRDF` field for the prepared material values. To make this change transparent to the user code, we provide a `typedef` in `ShaderCommon.slang` to define `ShadingAttribsImpl<PreparedMaterialData` as the new `ShadingAttribs`.
3. Change `IMaterial` interface to feature a `prepare` method that returns ShadingAttribsImpl<PreparedMaterialData>. Eventually it should return `ShadingAttribsImpl<TBRDF>` where TBRDF is the associated type of the material implmentation. But that is the next step.
4. Update the `evalMaterial` functions to be generic functions with a TBRDF type parameter. The implementation of the new `evalMaterial` function simply calls `IBRDF.eval()`, where the original `evalMaterial` core logic is moved to `PreparedMaterialData.eval()` .
5. Slightly change the deferred lighting pass shader in the `SimpleDeferred` example to work with the new shader library. Specifically, `LightingPassCommon.h` is renamed to `LightingPassCommon.slang`, and `LightingPass.ps.hlsl` simply fetches the parameter data from constant buffers and call the `shade` function defined in `LightingPassCommon.slang`.
  